### PR TITLE
fix presumed typo in `export LANG=...` line

### DIFF
--- a/README.org
+++ b/README.org
@@ -68,7 +68,7 @@ nano /etc/locale.gen
 #+end_src
 #+begin_src sh
 locale-gen
-echo LANG=en_US.UTF8 > /etc/locale.conf
+echo LANG=en_US.UTF-8 > /etc/locale.conf
 export LANG=en_US.UTF-8
 #+end_src
 *** 10. Set up mkinitcpio hooks and run


### PR DESCRIPTION
Every other reference to the `en_US.UTF-8` lang puts a dash between `UTF` and `8`, so I assume this was a typo?
