### PR TITLE
addded a fourth alternative for internet

### DIFF
--- a/README.org
+++ b/README.org
@@ -34,7 +34,8 @@ mkdir /mnt/boot && mount /dev/sda5 /mnt/boot
 This requires an internet connection. Options:
 - Tethered phone via USB ([[https://wiki.archlinux.org/index.php/Android_tethering][instructions for Android]], [[https://wiki.archlinux.org/index.php/IPhone_Tethering][instructions for iPhone]])
 - Wired (with some Apple proprietary ethernet thing ($$$?))
-- Wireless (requires b43 wireless firmware ([[https://aur.archlinux.org/packages/b43-firmware/][AUR]]))
+- Builtin Wireless (requires b43 wireless firmware ([[https://aur.archlinux.org/packages/b43-firmware/][AUR]]))
+- Third-party USB Wireless ($?, [[http://www.linux-hardware-guide.com/2014-06-06-d-link-dwa-121-usb-wifi-802-11n]][example device])
 #+begin_src sh
 pacstrap /mnt base base-devel
 genfstab -U -p /mnt >> /mnt/etc/fstab


### PR DESCRIPTION
After finding the Tethered phone approach to be inconsistent (sometimes `ifuse` would see the phone, sometimes not), and the built-in wireless failed to work, I went out today to buy the "Apple proprietary ethernet thing".  But you cannot seem to get it from the Apple stores, at least not the physical ones; they've moved on to Thunderbolt-oriented devices alone, since that's what the current Air models supply.

I looked for a USB <-> ethernet adapter at another store, but could not find one.

What I _did_ find was a third-party (D-link) USB to internet adapter.  I quickly googled the model numbers, figured out which one had built-in support via the site linked above, and bought it for about $12.

And huzzah, this has led to a much smoother installation experience for me.

So I figured I would suggest adding it to the list above.
